### PR TITLE
Add FilterTest to test-suite.other-modules

### DIFF
--- a/pandoc-include-code.cabal
+++ b/pandoc-include-code.cabal
@@ -43,6 +43,7 @@ executable pandoc-include-code
 test-suite filter-tests
     type:            exitcode-stdio-1.0
     hs-source-dirs:  test
+    other-modules:   FilterTest
     main-is:         Driver.hs
     build-depends:   base                 >= 4        && < 5
                    , pandoc-types         >= 1.12     && <= 1.19


### PR DESCRIPTION
This fixes a warning when doing `stack test`:
```
Warning: The following modules should be added to exposed-modules or other-modules in pandoc-include-code/pandoc-include-code.cabal:
             - In filter-tests component:
                 FilterTest
```
It also allows the project to build on NixOS whereas before I had the following problem:
```
Building test suite 'filter-tests' for pandoc-include-code-1.2.0.2..
[1 of 1] Compiling Main             ( test/Driver.hs, dist/build/filter-tests/filter-tests-tmp/Main.dyn_o )

test/Driver.hs:6:1: error:
    Could not find module ‘FilterTest’
    Use -v to see a list of the files searched for.
  |
6 | import qualified FilterTest
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```