### PR TITLE
include test fixtures in tarball

### DIFF
--- a/pandoc-include-code.cabal
+++ b/pandoc-include-code.cabal
@@ -15,6 +15,7 @@ category:            Documentation
 license:             MPL-2.0
 license-file:        LICENSE
 extra-source-files:  CHANGELOG.md
+                     test/fixtures/*.txt
 
 source-repository head
   type:     git


### PR DESCRIPTION
The tests fixtures are currently not included in the sdist tarball. This breaks the build under Nix.