### PR TITLE
Add removal of nested snippet comments

### DIFF
--- a/test/FilterTest.hs
+++ b/test/FilterTest.hs
@@ -75,4 +75,7 @@ tests =
         ["numberLines"]
         [("snippet", "foo")] `succeedsWith`
       CodeBlock ("", ["numberLines"], [("startFrom", "2")]) "foo\n"
+    , testCase "doesn't include nested snippet comments" $
+      includeCode "nested-snippets.txt" [] [("snippet", "global")] `succeedsWith`
+      codeBlock "global text\nnested text\n"
     ]

--- a/test/fixtures/nested-snippets.txt
+++ b/test/fixtures/nested-snippets.txt
@@ -1,0 +1,6 @@
+// start snippet global
+global text
+// start snippet nested
+nested text
+// end snippet nested
+// end snippet global


### PR DESCRIPTION
Implemented the feature requested in #16 by fully removing the snippet lines. Currently it does the filtering by default, however it could be hidden behind a configuration flag. 

The implementation is a bit "fragile" in the sense that if will only search for `snippet start ` and `snippet end` in _any_ line of text, and then remove it. Hence it might remove lines where "snippet start" is a part of the prose. I think this is an argument which makes hiding this behind a configuration flag sensible, as then the users enabling this feature understands the error. On the flipside, I do think it is probably rather rare to have `snippet start ` or `snippet end` in a comment.

EDIT: If you want this feature, I'll happily write a bit about it in the README before you merge this, so that it is documented aswell.