### PR TITLE
Support for pandoc 2.10+

### DIFF
--- a/pandoc-include-code.cabal
+++ b/pandoc-include-code.cabal
@@ -36,7 +36,7 @@ library
                    , filepath
                    , text                 >= 1.2      && < 2
                    , mtl                  >= 2.2      && < 3
-                   , pandoc-types         >= 1.20     && <= 1.20
+                   , pandoc-types         >= 1.21     && <= 1.21
 
 
 executable pandoc-include-code
@@ -44,7 +44,7 @@ executable pandoc-include-code
     main-is:         Main.hs
     other-modules:   Paths_pandoc_include_code
     build-depends:   base                 >= 4        && < 5
-                   , pandoc-types         >= 1.20     && <= 1.20
+                   , pandoc-types         >= 1.21     && <= 1.21
                    , pandoc-include-code
 
 test-suite filter-tests

--- a/pandoc-include-code.cabal
+++ b/pandoc-include-code.cabal
@@ -54,7 +54,7 @@ test-suite filter-tests
                    , Paths_pandoc_include_code
     main-is:         Driver.hs
     build-depends:   base                 >= 4        && < 5
-                   , pandoc-types         >= 1.20     && <= 1.20
+                   , pandoc-types         >= 1.21     && <= 1.21
                    , pandoc-include-code
                    , tasty
                    , tasty-hunit

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,2 @@
-resolver: lts-13.26
+resolver: nightly-2020-06-29 # GHC 8.10.1
 
-extra-deps:
-  - pandoc-types-1.20@sha256:8393b1a73b8a6a1f3feaeb3a6592c176461082c3e4d897f1b316b1a58dd84c39,3999


### PR DESCRIPTION
Hello,

This is a very small change that adds support for pandoc 2.10+. Fixes #30.

Laurent

P.S. If you need to use `pandoc-include-code` with pandoc 2.10 **right now**, and you are using `stack`, you can add the dependency as follows:

```yaml
extra-deps:
- git: https://github.com/LaurentRDC/pandoc-include-code.git
  commit: 162ae92edc80601bde8450bf933c0127e8c2b53a
```