### PR TITLE
pandoc-include-code: patch for pandoc 2.11

### DIFF
--- a/pandoc-include-code.cabal
+++ b/pandoc-include-code.cabal
@@ -36,7 +36,7 @@ library
                    , filepath
                    , text                 >= 1.2      && < 2
                    , mtl                  >= 2.2      && < 3
-                   , pandoc-types         >= 1.21     && <= 1.21
+                   , pandoc-types         >= 1.22     && <= 1.22
 
 
 executable pandoc-include-code
@@ -44,7 +44,7 @@ executable pandoc-include-code
     main-is:         Main.hs
     other-modules:   Paths_pandoc_include_code
     build-depends:   base                 >= 4        && < 5
-                   , pandoc-types         >= 1.21     && <= 1.21
+                   , pandoc-types         >= 1.22     && <= 1.22
                    , pandoc-include-code
 
 test-suite filter-tests
@@ -54,7 +54,7 @@ test-suite filter-tests
                    , Paths_pandoc_include_code
     main-is:         Driver.hs
     build-depends:   base                 >= 4        && < 5
-                   , pandoc-types         >= 1.21     && <= 1.21
+                   , pandoc-types         >= 1.22     && <= 1.22
                    , pandoc-include-code
                    , tasty
                    , tasty-hunit


### PR DESCRIPTION
```
==> /usr/local/opt/pandoc/bin/pandoc -F /usr/local/Cellar/pandoc-include-code/1.5.0.0_2/bin/pandoc-include-code -o out.html hello.md
pandoc-include-code: Error in $: Incompatible API versions: encoded with [1,22] but attempted to decode with [1,20].
CallStack (from HasCallStack):
  error, called at ./Text/Pandoc/JSON.hs:112:48 in pndc-typs-1.20-8d86ff1e:Text.Pandoc.JSON
Error running filter /usr/local/Cellar/pandoc-include-code/1.5.0.0_2/bin/pandoc-include-code:
Filter returned error status 1
```

relates to https://github.com/Homebrew/homebrew-core/pull/62771